### PR TITLE
[Fix #4] Remove faulty local variables

### DIFF
--- a/moe-theme.el
+++ b/moe-theme.el
@@ -65,9 +65,6 @@
                (file-name-as-directory (file-name-directory load-file-name))))
 
 ;; Local Variables:
-;; version-control: never
-;; no-byte-compile: t
-;; no-update-autoloads: t
 ;; coding: utf-8
 ;; End:
 ;;; moe-theme.el ends here


### PR DESCRIPTION
Remove faulty local variables from the theme file.

Remove `no-update-autoloads` because it prevents Emacs from evaluating the autoload cookies in this file, so that it ultimately fails to add itself to `custom-theme-load-path` and thus cannot be used.  See #4.  

Also remove `no-byte-compile` and `version-control` because these are really superfluous.
