### PR TITLE
Match comint mode colours with eshell.

### DIFF
--- a/moe-dark-theme.el
+++ b/moe-dark-theme.el
@@ -397,6 +397,9 @@ Moe, moe, kyun!")
    `(eshell-ls-unreadable ((,class (:foreground ,black-2))))
    `(eshell-prompt ((,class (:foreground ,white-0 :background ,black-2-5 :bold t))))
 
+   ;; Comint prompt
+   `(comint-highlight-prompt ((,class (:foreground ,white-0 :background ,black-2-5 :bold t))))
+
    ;; which-function-mode
    `(which-func ((,class (:foreground ,white-0 :background ,orange-2))))
 

--- a/moe-light-theme.el
+++ b/moe-light-theme.el
@@ -397,6 +397,9 @@ Moe, moe, kyun!")
    `(eshell-ls-unreadable ((,class (:foreground ,black-2))))
    `(eshell-prompt ((,class (:foreground ,black-3 :background ,yellow-0 :bold t))))
 
+   ;; Comint prompt
+   `(comint-highlight-prompt ((,class (:foreground ,black-3 :background ,yellow-0 :bold t))))
+
    ;; which-function-mode
    `(which-func ((,class (:foreground ,white-0 :background ,orange-2))))
 


### PR DESCRIPTION
Playing around with the theme, I like it a lot so far. I threw together a theme for [st](http://st.suckless.org/) in this [gist](https://gist.github.com/jcpetkovich/8049651).

I have a suggestion though, I think for consistency with eshell, comint-mode should get similar colours.

At current:

![green-comint](https://f.cloud.github.com/assets/159257/1788370/b7932c14-6926-11e3-9c3e-1ac03799abe8.png)

Vs with eshell's prompt colours:

![dark-comint](https://f.cloud.github.com/assets/159257/1788371/c4ea397a-6926-11e3-9aac-9d0f90ea75c3.png)
