### PR TITLE
Add lighter purple for file names in helm-grep.

### DIFF
--- a/moe-dark-theme.el
+++ b/moe-dark-theme.el
@@ -296,6 +296,7 @@ Moe, moe, kyun!")
    `(helm-ff-invalid-symlink ((,class (:foreground ,white-1 :background ,red-2))))
    `(helm-ff-prefix ((,class (:foreground ,white-1 :background ,orange-2))))
    `(helm-buffer-size ((,class (:foreground ,orange-2))))
+   `(helm-grep-file ((,class (:foreground ,purple-1))))
 
    ;; Dired/Dired+
    `(dired-directory ((,class (:foreground ,blue-1 :bold t))))


### PR DESCRIPTION
The default purple used by `helm` for showing files during a `grep` operation are pretty dark. It's difficult to read using the `moe-dark-theme`.

For comparison, here is before the change:

![moe-dark-original-purple](https://f.cloud.github.com/assets/159257/2181035/aa2e4ad0-973f-11e3-910e-e6d72ea9964b.png)

Here is after:

![moe-dark-lighter-purple](https://f.cloud.github.com/assets/159257/2181036/b1bbfedc-973f-11e3-8848-7068220bc13b.png)
