### PR TITLE
Faces for helm-lisp-show-completion

### DIFF
--- a/moe-dark-theme.el
+++ b/moe-dark-theme.el
@@ -298,6 +298,7 @@ Moe, moe, kyun!")
    `(helm-ff-prefix ((,class (:foreground ,white-1 :background ,orange-2))))
    `(helm-buffer-size ((,class (:foreground ,orange-2))))
    `(helm-grep-file ((,class (:foreground ,purple-1))))
+   `(helm-lisp-show-completion ((,class (:foreground ,black-3 :background ,green-0))))
 
    ;; Dired/Dired+
    `(dired-directory ((,class (:foreground ,blue-1 :bold t))))

--- a/moe-light-theme.el
+++ b/moe-light-theme.el
@@ -296,7 +296,7 @@ Moe, moe, kyun!")
    `(helm-ff-prefix ((,class (:foreground ,white-0 :background ,orange-2))))
    `(helm-buffer-size ((,class (:foreground ,orange-2))))
    `(helm-grep-file ((,class (:foreground ,purple-2))))
-   `(helm-lisp-show-completion ((,class (:background ,blue-1))))
+   `(helm-lisp-show-completion ((,class (:foreground ,white-0 :background ,blue-1))))
 
    ;; Dired/Dired+
    `(dired-directory ((,class (:foreground ,blue-1 :bold t))))


### PR DESCRIPTION
The default colour for helm-lisp-show-completion (DarkSlateGray) is impossible to read in moe-light, and somewhat difficult in moe-dark.

I decided that the region colours might work better, although maybe you can think of something better than that:

![dark-colour](https://f.cloud.github.com/assets/159257/2360692/bead23fe-a627-11e3-862d-937ad987d58b.png)

![light-colour](https://f.cloud.github.com/assets/159257/2360695/c408b412-a627-11e3-8824-76f1c2538159.png)

In these images I'm running some helm completion based on the eshell history, you can see that the currently selected item is mirrored on the eshell commandline. This mirrored text is what is governed by the `helm-lisp-show-completion` face.
