### PR TITLE
Refactor moe-theme-select-color and random-color

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,10 +97,10 @@ The values should be lists. Larger the values, larger the fonts.
 If you don't like this, just leave them nil, and all the titles will be the same size.
 
 ### Colorful Mode-line and Powerline
-Tired of boring blue mode-line? You can set default mode-line color. moe-theme provides 9 colors mode-line style. Add following lines **before** `(moe-light)` or `(moe-dark)`:
+Tired of boring blue mode-line? You can set default mode-line color. moe-theme provides 9 colors mode-line style. Add following lines **after** `(moe-light)` or `(moe-dark)`:
 
 ```lisp
-  (setq moe-theme-mode-line-color 'orange)
+  (moe-theme-set-color 'orange)
   ;; (Available colors: blue, orange, green ,magenta, yellow, purple, red, cyan, w/b.)
 ```
 
@@ -164,7 +164,7 @@ If your terminal emulator doesn't render 256-color output correctly, set its env
     TERM=xterm-256color
 
 If you also use `tmux`, add this to `~/.tmux.conf`, too:
-	
+
     set -g default-terminal "screen-256color"
 
 ### Paren
@@ -187,4 +187,3 @@ Can't bear a mode with an ugly looking? `moe-theme` doesn't support the mode you
 
 ## License
 `moe-theme.el` (include images) is released under GPL v3. Copyleft is so cute!
-

--- a/moe-theme.el
+++ b/moe-theme.el
@@ -377,21 +377,26 @@ Don't setq this manually.")
 
 ;; Powerline
 
-(defun moe-theme-select-color ()
-  "Select the color of mode-line you like. (Notice: we support Powerline :D)
-You may also like `moe-theme-random-color'"
-  (interactive)
+(defun moe-theme-set-color (color)
+  "Set the COLOR of mode-line you like. (Notice: we support
+Powerline :D) You may also like `moe-theme-random-color'"
   (setq moe-theme-mode-line-color
-        (intern (completing-read
-                 "Select a color: "
-                 '((blue) (green) (orange) (magenta) (yellow) (purple) (red) (cyan) (w/b))
-                 nil t "" nil nil t)))
+		color)
     (let (moe-theme-revert-theme) ;set to nil to change only mode-line's color
       (if (eq (frame-parameter nil 'background-mode) 'light)
           (moe-light)
         (moe-dark)))
   (if (eq moe-theme-powerline-enable-p t)
       (powerline-moe-theme)))
+
+(defun moe-theme-select-color ()
+  "Select the color of mode-line you like and set it. (Notice: we
+support Powerline :D) You may also like `moe-theme-random-color'"
+  (interactive)
+  (moe-theme-set-color (intern (completing-read
+                 "Select a color: "
+                 '((blue) (green) (orange) (magenta) (yellow) (purple) (red) (cyan) (w/b))
+                 nil t "" nil nil t))))
 
 (defun moe-theme-random-color ()
   "Give me a random mode-line color.=w=+"
@@ -401,14 +406,7 @@ You may also like `moe-theme-random-color'"
          (color-list '(blue green orange magenta yellow purple red cyan w/b)))
     (if (eq (elt color-list n) current-color) ;If gotten color eq current-color, random again.
         (moe-theme-random-color)
-      (setq moe-theme-mode-line-color (elt color-list n)))
-
-    (let (moe-theme-revert-theme) ;set to nil to change only mode-line's color
-      (if (eq (frame-parameter nil 'background-mode) 'light)
-          (moe-light)
-        (moe-dark)))
-    (if (eq moe-theme-powerline-enable-p t)
-        (powerline-moe-theme))))
+      (moe-theme-set-color (elt color-list n)))))
 
 (when (require 'powerline nil :no-error)
   (defadvice powerline-revert (after moe-theme-powerline-revert activate)


### PR DESCRIPTION
When I used to call the follow to set my theme, it would never work
quite the same as if I directly called `moe-theme-select-color`
manually.

``` elisp
(setq moe-theme-mode-line-color 'purple)
(powerline-moe-theme)
```

For example, the file completion of IDO would never change
from blue. To eleminate this, I refactored the code you were using in
`moe-theme-select-color` out into it's own function, which both
`moe-theme-select-color` and `moe-theme-random-color` now both call
rather than independantly recreating the same logic.
