### PR TITLE
Bold and Italic shouldn't be overwritten

### DIFF
--- a/moe-dark-theme.el
+++ b/moe-dark-theme.el
@@ -57,8 +57,6 @@ Moe, moe, kyun!")
    `(trailing-whitespace ((,class (:background ,red-3))))
    `(show-paren-match ((,class (:background ,blue-3 :foreground nil))))
    `(header-line ((,class (:background ,blue-3 :foreground ,white-0 :underline nil))))
-   `(bold ((,class (:background nil :foreground ,white-0 :bold t))))
-   `(italic ((,class (:background nil :foreground ,white-0 :italic t))))
    `(help-argument-name ((,class (:foreground ,magenta-1 :italic t))))
 
    ;; Mode line & frames' faces

--- a/moe-light-theme.el
+++ b/moe-light-theme.el
@@ -56,8 +56,6 @@ Moe, moe, kyun!")
    `(trailing-whitespace ((,class (:background ,red-3))))
    `(show-paren-match ((,class (:background ,blue-00))))
    `(header-line ((,class (:background ,blue-1 :foreground ,white-0 :underline t))))
-   `(bold ((,class (:background nil :foreground ,black-6 :bold t))))
-   `(italic ((,class (:background nil :foreground ,red-3 :italic t :underline nil))))
    `(help-argument-name ((,class (:foreground ,magenta-3 :italic t))))
 
    ;; Mode line & frames' faces


### PR DESCRIPTION
If you overwrite the colors for bold and italic, then in cases where
emphasis is being applied over an existing face, the existing color is
overwritten. If we're not overwriting the color, then we don't need these 
class definitions at all (since bold and italic are part of the `defface`)

Examples in org-mode with current moe-theme master:

![screen shot 2014-11-03 at 14 18 39](https://cloud.githubusercontent.com/assets/1134611/4891391/af7f35a0-63a7-11e4-82bb-fdc81d487fa5.png)
![screen shot 2014-11-03 at 14 18 51](https://cloud.githubusercontent.com/assets/1134611/4891393/b15f1282-63a7-11e4-900e-8b222fe9641e.png)

Examples in org-mode with applied changes:
![screen shot 2014-11-03 at 14 17 16](https://cloud.githubusercontent.com/assets/1134611/4891406/c227bcf4-63a7-11e4-8649-c411f75ff6c1.png)
![screen shot 2014-11-03 at 14 17 34](https://cloud.githubusercontent.com/assets/1134611/4891407/c47fefe4-63a7-11e4-87ff-14dfe30f29a0.png)
