### PR TITLE
Add support for avy-mode

### DIFF
--- a/moe-dark-theme.el
+++ b/moe-dark-theme.el
@@ -609,6 +609,12 @@ Moe, moe, kyun!")
    `(ace-jump-face-background ((,class (:background nil :foreground ,black-2-5))))
    `(ace-jump-face-foreground ((,class (:foreground ,orange-2 :bold t))))
 
+   ;; avy-mode
+   `(avy-lead-face ((,class (:background ,cyan-1 :foreground ,black-4))))
+   `(avy-lead-face-0 ((,class (:background ,purple-00 :foreground ,black-4))))
+   `(avy-lead-face-1 ((,class (:background ,white-2 :foreground ,black-4))))
+   `(avy-lead-face-2 ((,class (:background ,green-2 :foreground ,black-4))))
+
    ;; Rainbow-delimiters
    `(rainbow-delimiters-depth-1-face ((,class (:bold t :foreground ,red-2))))
    `(rainbow-delimiters-depth-2-face ((,class (:bold t :foreground ,blue-1))))

--- a/moe-light-theme.el
+++ b/moe-light-theme.el
@@ -607,6 +607,12 @@ Moe, moe, kyun!")
    `(ace-jump-face-background ((,class (:foreground ,white-4))))
    `(ace-jump-face-foreground ((,class (:foreground ,red-2 :bold t))))
 
+   ;; avy-mode
+   `(avy-lead-face ((,class (:background ,cyan-1 :foreground ,black-4))))
+   `(avy-lead-face-0 ((,class (:background ,purple-00 :foreground ,black-4))))
+   `(avy-lead-face-1 ((,class (:background ,white-2 :foreground ,black-4))))
+   `(avy-lead-face-2 ((,class (:background ,green-2 :foreground ,black-4))))
+
    ;; Rainbow-delimiters
    `(rainbow-delimiters-depth-1-face ((,class (:bold t :foreground ,red-2))))
    `(rainbow-delimiters-depth-2-face ((,class (:bold t :foreground ,blue-2))))


### PR DESCRIPTION
avy: https://github.com/abo-abo/avy a replacement to ace-jump-mode

Example in moe-light:
![screen shot 2016-06-06 at 13 43 44](https://cloud.githubusercontent.com/assets/1134611/15837202/1af94776-2bed-11e6-8abe-282010a41b90.png)

Example in moe-dark:
![screen shot 2016-06-06 at 13 44 00](https://cloud.githubusercontent.com/assets/1134611/15837207/1e3c6576-2bed-11e6-9896-c671d91d0f39.png)

Note: I'm not tied to these particular colors I chose at all, just needed something different than the default since it was impossible to read certain candidate faces on top of error faces.