### PR TITLE
Add faces for Cider deprecated functions

### DIFF
--- a/moe-dark-theme.el
+++ b/moe-dark-theme.el
@@ -671,10 +671,11 @@ Moe, moe, kyun!")
    `(mmm-output-submode-face ((,class (:background ,purple-00))))
    `(mmm-special-submode-face ((,class (:background ,green-00))))
 
-   ;; Clojure
+   ;; Clojure/Cider
    `(clojure-test-failure-face ((,class (:underline ,orange-2))))
    `(clojure-test-error-face ((,class (:underline ,red-2))))
    `(clojure-test-success-face ((,class (:underline ,green-3))))
+   `(cider-deprecated-face ((,class (:background ,red-4))))
 
    ;; Javascript
    `(js2-function-param-face ((,class (:foreground ,green-3))))

--- a/moe-light-theme.el
+++ b/moe-light-theme.el
@@ -669,10 +669,11 @@ Moe, moe, kyun!")
    `(mmm-output-submode-face ((,class (:background ,purple-00))))
    `(mmm-special-submode-face ((,class (:background ,green-00))))
 
-   ;; Clojure
+   ;; Clojure/Cider
    `(clojure-test-failure-face ((,class (:underline ,orange-2))))
    `(clojure-test-error-face ((,class (:underline ,red-2))))
    `(clojure-test-success-face ((,class (:underline ,green-3))))
+   `(cider-deprecated-face ((,class (:background ,red-00))))
 
    ;; Javascript
    `(js2-function-param-face ((,class (:foreground ,green-3))))


### PR DESCRIPTION
Add faces for cider's, a minor mode for clojure development, deprecated font face.