### PR TITLE
Remove background from tuareg mode operators

### DIFF
--- a/moe-dark-theme.el
+++ b/moe-dark-theme.el
@@ -884,7 +884,7 @@ Moe, moe, kyun!")
    `(tuareg-font-lock-interactive-error-face ((,class (:foreground ,red-3 :background ,red-00 :bold t))))
    `(tuareg-font-lock-interactive-output-face ((,class (:foreground ,blue-3))))
    `(tuareg-font-lock-multistage-face ((,class (:foreground ,blue-3 :background ,blue-0))))
-   `(tuareg-font-lock-operator-face ((,class (:foreground ,green-2 :background ,black-3 :bold t))))
+   `(tuareg-font-lock-operator-face ((,class (:foreground ,green-2 :bold t))))
 
    ;; CPerl
    `(cperl-array-face ((,class (:foreground ,blue-01 :background ,blue-3))))

--- a/moe-light-theme.el
+++ b/moe-light-theme.el
@@ -890,7 +890,7 @@ Moe, moe, kyun!")
    `(tuareg-font-lock-interactive-error-face ((,class (:foreground ,red-3 :background ,red-00 :bold t))))
    `(tuareg-font-lock-interactive-output-face ((,class (:foreground ,blue-3))))
    `(tuareg-font-lock-multistage-face ((,class (:foreground ,blue-3 :background ,blue-0))))
-   `(tuareg-font-lock-operator-face ((,class (:foreground ,green-3 :background ,yellow-00 :bold t))))
+   `(tuareg-font-lock-operator-face ((,class (:foreground ,green-3 :bold t))))
 
    ;; CPerl
    `(cperl-array-face ((,class (:foreground ,blue-3 :background ,blue-00))))


### PR DESCRIPTION
If this is intentional, I'm happy to keep it patched on my side, but it looks odd to me and it doesn't seem consistent with the rest of the theme on the other modes that I use. That's why I thought it might be an oversight. Anyway, this mode is really nice - thank you.

Old:
![old](https://user-images.githubusercontent.com/1592315/37427546-0ee4379a-27ca-11e8-9b5e-4a41d62957cf.png)

Changed:
![changed](https://user-images.githubusercontent.com/1592315/37427567-1900f330-27ca-11e8-9484-fc6e39bd3f9d.png)
