### PR TITLE
Maybe fixed the bug when installing over MELPA

### DIFF
--- a/moe-theme.el
+++ b/moe-theme.el
@@ -497,6 +497,14 @@ as long as setq `moe-theme-mode-line-color' first."
     (setq moe-theme-powerline-enable-p t)))
 
 
+;;;###autoload
+(when (and (boundp 'custom-theme-load-path)
+           load-file-name)
+  ;; add theme folder to `custom-theme-load-path' when installing over MELPA
+  (add-to-list 'custom-theme-load-path
+               (file-name-as-directory (file-name-directory load-file-name))))
+
+
 (provide 'moe-theme)
 
 ;; Local Variables:


### PR DESCRIPTION
Other themes have this line code, but not moe-theme.

Maybe fixed #83 and #92 