### PR TITLE
notmuch: Distinguishable color for single-line message summary

### DIFF
--- a/moe-dark-theme.el
+++ b/moe-dark-theme.el
@@ -795,7 +795,7 @@ Moe, moe, kyun!")
 
    ;; notmuch
    `(notmuch-search-unread-face ((,class (:weight bold))))
-   `(notmuch-message-summary-face ((,class (:background "#0f0f0f"))))
+   `(notmuch-message-summary-face ((,class (:background ,black-4))))
 
    ;; git-gutter (&-fringe)
    `(git-gutter:added ((,class (:foreground ,green-4 :background ,green-0 :bold t))))

--- a/moe-dark-theme.el
+++ b/moe-dark-theme.el
@@ -795,6 +795,7 @@ Moe, moe, kyun!")
 
    ;; notmuch
    `(notmuch-search-unread-face ((,class (:weight bold))))
+   `(notmuch-message-summary-face ((,class (:background "#0f0f0f"))))
 
    ;; git-gutter (&-fringe)
    `(git-gutter:added ((,class (:foreground ,green-4 :background ,green-0 :bold t))))

--- a/moe-light-theme.el
+++ b/moe-light-theme.el
@@ -793,7 +793,7 @@ Moe, moe, kyun!")
 
    ;; notmuch
    `(notmuch-search-unread-face ((,class (:weight bold))))
-   `(notmuch-message-summary-face ((,class (:background "#f0f0f0"))))
+   `(notmuch-message-summary-face ((,class (:background ,white-1))))
 
    ;; git-gutter (&-fringe)
    `(git-gutter:added ((,class (:foreground ,green-4 :background ,green-0 :bold t))))

--- a/moe-light-theme.el
+++ b/moe-light-theme.el
@@ -793,6 +793,7 @@ Moe, moe, kyun!")
 
    ;; notmuch
    `(notmuch-search-unread-face ((,class (:weight bold))))
+   `(notmuch-message-summary-face ((,class (:background "#f0f0f0"))))
 
    ;; git-gutter (&-fringe)
    `(git-gutter:added ((,class (:foreground ,green-4 :background ,green-0 :bold t))))


### PR DESCRIPTION
When reading e-mails in notmuch with the dark theme, it is hard to visually tell when one message ends and the next message begins:
![notmuch-moe-unpatched](https://user-images.githubusercontent.com/9089216/74608719-62240400-5098-11ea-9e49-f58239f6f807.png)
This patch changes the color of the first-line message summary to `gray6`, so that it is easier to see that a new message has started:
![notmuch-moe-patched](https://user-images.githubusercontent.com/9089216/74608720-63edc780-5098-11ea-8b6d-b02222805a2b.png)
The default color in the light background (`gray94`) already works well:
![notmuch-moe-light](https://user-images.githubusercontent.com/9089216/74608717-5df7e680-5098-11ea-969a-09983f2c81b8.png)
But for consistency's sake, I've also added a line to `moe-light-theme.el` explicitly setting the value of `notmuch-message-summary-face` to its default.
