### PR TITLE
Change for using cl-lib instead of cl. cl is deprecated

### DIFF
--- a/moe-theme.el
+++ b/moe-theme.el
@@ -25,7 +25,7 @@
 
 (require 'moe-light-theme)
 (require 'moe-dark-theme)
-(require 'cl)
+(require 'cl-lib)
 
 ;; ======================================================
 ;; Buffer ID


### PR DESCRIPTION
package cl is deprecated, it is discouraged to use it. Instead use cl-lib.
cl requires cl-lib internally, so we end up using cl-lib indirectly 