### PR TITLE
Turn off aggressive-indent-mode only if it's actually on.

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -3,4 +3,5 @@
 
 ((emacs-lisp-mode
   (eval . (progn
-            (aggressive-indent-mode -1)))))
+            (when (fboundp 'aggressive-indent-mode)
+              (aggressive-indent-mode -1))))))


### PR DESCRIPTION
This is a minor fix. I don't use aggressive-indent and this causes a not found failure.