### PR TITLE
NonGNU ELPA fixes: add license/copyright headers and version

### DIFF
--- a/moe-dark-theme.el
+++ b/moe-dark-theme.el
@@ -1,7 +1,24 @@
 ;;; moe-dark-theme.el --- An eye-candy theme for Emacser
 
+;; Copyright (C) 2013-2022 kuanyui
+
 ;; Author: kuanyui<azazabc123@gmail.com>
 ;; Based on "tango-dark-theme"
+
+;; This file is not part of GNU Emacs.
+;;
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 ;;; Code:
 

--- a/moe-light-theme.el
+++ b/moe-light-theme.el
@@ -1,7 +1,24 @@
 ;;; moe-light-theme.el --- An eye-candy theme for Emacser
 
+;; Copyright (C) 2013-2022 kuanyui
+
 ;; Author: kuanyui<azazabc123@gmail.com>
 ;; Based on "tango-dark-theme"
+
+;; This file is not part of GNU Emacs.
+;;
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 ;;; Code:
 

--- a/moe-theme-switcher.el
+++ b/moe-theme-switcher.el
@@ -1,9 +1,24 @@
 ;; moe-theme-switcher.el
+
+;; Copyright (C) 2013-2022 kuanyui
+
 ;; Author: kuanyui (azazabc123@gmail.com)
 ;; Date: 2013/05/11 11:39
 ;;
-;; This file is not a part of GNU Emacs,
-;; but this file is released under GPL v3.
+;; This file is not part of GNU Emacs.
+;;
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 ;; TODO: This program need to be refactored.
 (require 'moe-dark-theme)

--- a/moe-theme.el
+++ b/moe-theme.el
@@ -9,7 +9,7 @@
 ;; Keywords: themes
 ;; X-URL: https://github.com/kuanyui/moe-theme.el
 ;; URL: https://github.com/kuanyui/moe-theme.el
-;; Version: {{VERSION}}
+;; Version: 0.1
 
 ;; This file is not part of GNU Emacs.
 ;;

--- a/moe-theme.el
+++ b/moe-theme.el
@@ -1,7 +1,7 @@
 ;;; moe-theme --- A colorful eye-candy theme. Moe, moe, kyun!
 
-;; This program is not part of GNU Emacs, but it is distributed under GPL v3 :-)
-;;
+;; Copyright (C) 2013-2022 kuanyui
+
 ;; This file is established for packaging. If you want to install manually,
 ;; check README.md
 ;;
@@ -10,6 +10,21 @@
 ;; X-URL: https://github.com/kuanyui/moe-theme.el
 ;; URL: https://github.com/kuanyui/moe-theme.el
 ;; Version: {{VERSION}}
+
+;; This file is not part of GNU Emacs.
+;;
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 ;;; Commentary:
 


### PR DESCRIPTION
Hi!

I am investigating if we could add this package to [NonGNU ELPA](http://elpa.nongnu.org/) (see link), a new Emacs Lisp package archive that will be enabled by default in Emacs 28. This means that users of that version or later will be able to install this package without any configuration: they can just run `M-x list-packages` and install it out of the box. We hope that this will improve Emacs and help bring new users to this package and others.

1. NonGNU ELPA has a requirement that all files must have a clear statement of its license and copyright status. I believe this patch would be sufficient to fulfill this requirement.

2. The main difference between NonGNU ELPA and MELPA is that only stable versions of packages are released. A new release will be made automatically when you bump the ";; Version: NNN" commentary header in this repository, as I do in the second commit. NonGNU ELPA does not look at any "git tag". In the future, you can bump the package version in that header (thereby releasing a new version) when you think it makes sense and at your convenience.

The rules for accepting a package into NonGNU ELPA are here, for your reference:
https://git.savannah.gnu.org/cgit/emacs/nongnu.git/tree/README.org#n133

Besides the copyright and license statements, this package already follows the rules so there should be nothing more to do with regards to that. However, it would be good if you could review them and let us know if you think there will be any problems with following any of them going forward. They should be straightforward and easy to follow, but note in particular that NonGNU ELPA does not distribute any package that recommends proprietary software.

Please let me know if you have any questions about NonGNU ELPA.

Thanks!