### PR TITLE
More NonGNU ELPA fixes

### DIFF
--- a/moe-theme.el
+++ b/moe-theme.el
@@ -1,4 +1,4 @@
-;;; moe-theme --- A colorful eye-candy theme. Moe, moe, kyun!
+;;; moe-theme.el --- A colorful eye-candy theme. Moe, moe, kyun!
 
 ;; Copyright (C) 2013-2022 kuanyui
 

--- a/moe-theme.el
+++ b/moe-theme.el
@@ -9,7 +9,7 @@
 ;; Keywords: themes
 ;; X-URL: https://github.com/kuanyui/moe-theme.el
 ;; URL: https://github.com/kuanyui/moe-theme.el
-;; Version: 0.1
+;; Version: 1.0.2
 
 ;; This file is not part of GNU Emacs.
 ;;


### PR DESCRIPTION
I found two more issues with adding this NonGNU ELPA:

1. The package header does not work correctly for `M-: (package-buffer-info)`.
2. There is a tag for version 1.0.1 already, that I had not previously seen. I am therefore bumping the version here to 1.0.2, and I would suggest also adding a `git tag` pointing to that bump commit.

Thanks again!