### PR TITLE
Add ansi colors for Emacs28

### DIFF
--- a/moe-dark-theme.el
+++ b/moe-dark-theme.el
@@ -1022,7 +1022,26 @@ Moe, moe, kyun!")
    `(rpm-spec-dir-face ((,class (:foreground ,green-2))))
    `(rpm-spec-package-face ((,class (:foreground ,red-0))))
    `(rpm-spec-ghost-face ((,class (:foreground ,red-0))))
-   `(rpm-spec-section-face ((,class (:foreground ,yellow-2)))))
+   `(rpm-spec-section-face ((,class (:foreground ,yellow-2))))
+
+   ;; ansi-color
+   `(ansi-color-black ((,class (:background ,black-5 :foreground ,black-5))))
+   `(ansi-color-red ((,class (:background ,red-0 :foreground ,red-0))))
+   `(ansi-color-green ((,class (:background ,green-0 :foreground ,green-0))))
+   `(ansi-color-yellow ((,class (:background ,yellow-1 :foreground ,yellow-1))))
+   `(ansi-color-blue ((,class (:background ,blue-1 :foreground ,blue-1))))
+   `(ansi-color-magenta ((,class (:background ,purple-1 :foreground ,purple-1))))
+   `(ansi-color-cyan ((,class (:background ,blue-0 :foreground ,blue-0))))
+   `(ansi-color-white ((,class (:background ,white-1 :foreground ,white-1))))
+   `(ansi-color-bright-black ((,class (:background ,black-5 :foreground ,black-5))))
+   `(ansi-color-bright-red ((,class (:background ,red-0 :foreground ,red-0))))
+   `(ansi-color-bright-green ((,class (:background ,green-0 :foreground ,green-0))))
+   `(ansi-color-bright-yellow ((,class (:background ,yellow-1 :foreground ,yellow-1))))
+   `(ansi-color-bright-blue ((,class (:background ,blue-1 :foreground ,blue-1))))
+   `(ansi-color-bright-magenta ((,class (:background ,purple-1 :foreground ,purple-1))))
+   `(ansi-color-bright-cyan ((,class (:background ,blue-0 :foreground ,blue-0))))
+   `(ansi-color-bright-white ((,class (:background ,white-1 :foreground ,white-1))))
+   `(ansi-color-bold ((,class (:inherit bold)))))
 
   (custom-theme-set-variables
    'moe-dark

--- a/moe-light-theme.el
+++ b/moe-light-theme.el
@@ -1028,7 +1028,26 @@ Moe, moe, kyun!")
    `(rpm-spec-dir-face ((,class (:foreground ,green-3))))
    `(rpm-spec-package-face ((,class (:foreground ,red-2))))
    `(rpm-spec-ghost-face ((,class (:foreground ,red-2))))
-   `(rpm-spec-section-face ((,class (:foreground ,red-1)))))
+   `(rpm-spec-section-face ((,class (:foreground ,red-1))))
+
+   ;; ansi-color
+   `(ansi-color-black ((,class (:background ,black-5 :foreground ,black-5))))
+   `(ansi-color-red ((,class (:background ,red-0 :foreground ,red-0))))
+   `(ansi-color-green ((,class (:background ,green-2 :foreground ,green-2))))
+   `(ansi-color-yellow ((,class (:background ,yellow-1 :foreground ,yellow-1))))
+   `(ansi-color-blue ((,class (:background ,blue-1 :foreground ,blue-1))))
+   `(ansi-color-magenta ((,class (:background ,purple-1 :foreground ,purple-1))))
+   `(ansi-color-cyan ((,class (:background ,blue-0 :foreground ,blue-0))))
+   `(ansi-color-white ((,class (:background ,white-0 :foreground ,white-0))))
+   `(ansi-color-bright-black ((,class (:background ,black-5 :foreground ,black-5))))
+   `(ansi-color-bright-red ((,class (:background ,red-0 :foreground ,red-0))))
+   `(ansi-color-bright-green ((,class (:background ,green-2 :foreground ,green-2))))
+   `(ansi-color-bright-yellow ((,class (:background ,yellow-1 :foreground ,yellow-1))))
+   `(ansi-color-bright-blue ((,class (:background ,blue-1 :foreground ,blue-1))))
+   `(ansi-color-bright-magenta ((,class (:background ,purple-1 :foreground ,purple-1))))
+   `(ansi-color-bright-cyan ((,class (:background ,blue-0 :foreground ,blue-0))))
+   `(ansi-color-bright-white ((,class (:background ,white-0 :foreground ,white-0))))
+   `(ansi-color-bold ((,class (:inherit bold)))))
 
   (custom-theme-set-variables
    'moe-light


### PR DESCRIPTION
Emacs 28.1 has introduced new faces for ansi colors as mentioned below ([See changelogs for reference](https://www.gnu.org/software/emacs/news/NEWS.28.1)):
```
** ANSI color

*** Colors are now defined by faces.
ANSI SGR codes now have corresponding faces to describe their
appearance, e.g. 'ansi-color-bold'.

*** Support for "bright" color codes.
"Bright" ANSI color codes are now displayed when applying ANSI color
filters using the color values defined by the faces
'ansi-color-bright-COLOR'.  In addition, bold text with regular ANSI
colors can be displayed as "bright" if 'ansi-color-bold-is-bright' is
non-nil.
```

This pull request adds support for the new faces and uses the same colors which were used for ansi-colors previously.