### PR TITLE
fix: more idiomatic way to get second element of list

### DIFF
--- a/moe-theme-switcher.el
+++ b/moe-theme-switcher.el
@@ -122,12 +122,12 @@ Take Keelung, Taiwan(25N,121E) for example, you can set like this:
                    (> (car now) (car 24h/sunrise))
                    (and
                     (= (car now) (car 24h/sunrise))
-                    (>= (second now) (second 24h/sunrise))))
+                    (>= (cadr now) (cadr 24h/sunrise))))
                   (or
                    (< (car now) (car 24h/sunset))
                    (and
                     (= (car now) (car 24h/sunset))
-                    (< (second now) (second 24h/sunset)))))
+                    (< (cadr now) (cadr 24h/sunset)))))
              (moe-load-theme 'light)
            (moe-load-theme 'dark)
            ))))))


### PR DESCRIPTION
`second` does not seem to available any longer in emacs-29.1 and I am not using `cl-lib` which is probably is larger issue here.