### PR TITLE
Fix org mode styling for Emacs 30

### DIFF
--- a/moe-dark-theme.el
+++ b/moe-dark-theme.el
@@ -161,9 +161,9 @@ Moe, moe, kyun!")
 					:box (:line-width 1 :style released-button)))))
    `(org-date ((,class (:foreground ,blue-0 :underline t))))
    `(org-done ((,class (:bold t :weight bold :foreground ,green-4 :background ,green-0
-                              :box (:line-width 1 :style none)))))
+                              :box (:line-width 1 ,@(when (version< emacs-version "30") '(:style none)))))))
    `(org-todo ((,class (:bold t :weight bold :foreground ,red-3 :background ,orange-0
-                              :box (:line-width 1 :style none)))))
+                              :box (:line-width 1 ,@(when (version< emacs-version "30") '(:style none)))))))
    `(org-level-1 ((,class (:foreground ,blue-1))))
    `(org-level-2 ((,class (:foreground ,green-2))))
    `(org-level-3 ((,class (:foreground ,orange-2))))

--- a/moe-light-theme.el
+++ b/moe-light-theme.el
@@ -161,9 +161,9 @@ Moe, moe, kyun!")
                                         :box (:line-width 1 :style released-button)))))
    `(org-date ((,class (:foreground ,blue-2 :underline t))))
    `(org-done ((,class (:bold t :weight bold :foreground ,green-4 :background ,green-00
-                              :box (:line-width 1 :style none)))))
+                              :box (:line-width 1 ,@(when (version< emacs-version "30") '(:style none)))))))
    `(org-todo ((,class (:bold t :weight bold :foreground ,red-3 :background ,orange-0
-                              :box (:line-width 1 :style none)))))
+                              :box (:line-width 1 ,@(when (version< emacs-version "30") '(:style none)))))))
    `(org-level-1 ((,class (:bold t :foreground ,blue-1))))
    `(org-level-2 ((,class (:bold t :foreground ,green-02))))
    `(org-level-3 ((,class (:bold t :foreground ,orange-2))))


### PR DESCRIPTION
Emacs 30 no longer supports `:box (:style none)`. Without this change, upon loading the theme, we see this error:

```
face-spec-set-2: Invalid face box: :line-width, 1, :style, none`
```

This has also been noticed in
https://github.com/doomemacs/themes/issues/809.

This change simply omits `:style none` when the Emacs version is >=30.