### PR TITLE
Add theme switcher minor mode

### DIFF
--- a/README.org
+++ b/README.org
@@ -208,6 +208,18 @@ I recommend set the value of =show-paren-style= to =expression= for better visua
         (setq show-paren-style 'expression)
 #+END_SRC
 
+** Changelog
+
+Notable changes from earlier versions of =moe-theme=:
+
+*** v1.1.0
+- =moe-theme-switcher= is now a minor mode
+
+  In previous versions, =moe-theme-switcher= was enabled automatically
+  by just loading the module. As it has now been turned into a minor
+  mode, users will need to update their configuration to enable this
+  mode. See [[* Switch between light and dark theme by time of daylight][this section]] for details on how to do this.
+
 ** Known Issues
 - If you add =(moe-dark)= or =(moe-light)= to your init file, the color
   of =buffer-id= would be incorrect after startuping CLI Emacs(but if

--- a/README.org
+++ b/README.org
@@ -165,6 +165,23 @@ Now =moe-theme= supports [[https://github.com/milkypostman/powerline][Powerline]
     (powerline-moe-theme)
 #+END_SRC
 
+*** Switch between light and dark theme by time of daylight
+
+This package also contains some rudimentary functionality for swapping
+between the =moe-light= and =moe-dark= themes automatically, to match
+the time of day. To enable it, you can use the following:
+
+#+BEGIN_SRC emacs-lisp
+  (require 'moe-theme-switcher)
+  (setq calendar-latitude +25
+        calendar-longitude +121
+        moe-theme-switch-by-sunrise-and-sunset t)
+  (moe-theme-switcher-mode 1)
+#+END_SRC
+
+For packages that provides more sophisticated switching functionality,
+see [[https://github.com/guidoschmidt/circadian.el][circadian.el]] or [[https://github.com/hadronzoo/theme-changer][theme-changer]].
+
 ** Frenquently Asked Problems
 *** No 256-Color Output?
 

--- a/moe-theme-switcher.el
+++ b/moe-theme-switcher.el
@@ -41,30 +41,37 @@ Take Keelung, Taiwan(25N,121E) for example, you can set like this:
 	(setq calendar-longitude +121)"
 )
 
-(defvar moe-theme-which-enabled nil
+(defvar moe-theme-switcher--which-enabled nil
   "Variable indicate which theme (moe-dark or light) is being used.")
 
-(defun moe-load-theme (switch-to)
+(defvar moe-theme-switcher--24h/sunrise)
+
+(defvar moe-theme-switcher--24h/sunset)
+
+(defvar moe-theme-switcher--timer nil
+  "Timer for checking whether to switch themes between `moe-light' and `moe-dark'.")
+
+(defun moe-theme-switcher--load-theme (switch-to)
   "Avoid unnecessary load-theme and screen flashing in GUI version Emacs"
   (cond ((equal switch-to 'light)
-         (if (not (equal moe-theme-which-enabled 'light))
+         (if (not (equal moe-theme-switcher--which-enabled 'light))
            (progn (moe-light)
-                  (setq moe-theme-which-enabled 'light)))) ;[FIXME] Maybe unnecessary
+                  (setq moe-theme-switcher--which-enabled 'light)))) ;[FIXME] Maybe unnecessary
         ((equal switch-to 'dark)
-         (if (not (equal moe-theme-which-enabled 'dark))
+         (if (not (equal moe-theme-switcher--which-enabled 'dark))
            (progn (moe-dark)
-                  (setq moe-theme-which-enabled 'dark)))))) ;[FIXME] Maybe unnecessary
+                  (setq moe-theme-switcher--which-enabled 'dark)))))) ;[FIXME] Maybe unnecessary
 
-(defun switch-at-fixed-time ()
+(defun moe-theme-switcher--switch-at-fixed-time ()
   (let ((now (string-to-number (format-time-string "%H"))))
     (if (and (>= now 06) (<= now 18))
-        (moe-load-theme 'light)
-      (moe-load-theme 'dark))
+        (moe-theme-switcher--load-theme 'light)
+      (moe-theme-switcher--load-theme 'dark))
     nil))
 
 ;; (Thanks for letoh!)
 ;; Fix strange bahavior of sunrise-sunset when buffer's width is too narrow.
-(defun get-sunrise-sunset-string ()
+(defun moe-theme-switcher--get-sunrise-sunset-string ()
   "get the real result from `sunrise-sunset'"
   (save-window-excursion
     (let ((regex "[0-9]+:[0-9]+[ap]m")
@@ -83,17 +90,17 @@ Take Keelung, Taiwan(25N,121E) for example, you can set like this:
 
 ;; Convert am/pm to 24hr and save to 24h/sunrise & 24h/set
 ;; Excute every 24 hr
-(defun convert-time-format-of-sunrise-and-sunset ()
+(defun moe-theme-switcher--compute-sunrise-sunset ()
   (let (rise_set a b c d e f)
-    (setq rise_set (get-sunrise-sunset-string))
+    (setq rise_set (moe-theme-switcher--get-sunrise-sunset-string))
     (if (string-match "0:00 hours daylight" rise_set) ;If polar-night
         (progn
-          (setq 24h/sunrise 'polar-night
-                24h/sunset 'polar-night))
+          (setq moe-theme-switcher--24h/sunrise 'polar-night
+                moe-theme-switcher--24h/sunset 'polar-night))
       (if (string-match "24:00 hours daylight" rise_set) ;If midnight-sun
           (progn
-            (setq 24h/sunrise 'midnight-sun
-                  24h/sunset 'midnight-sun))
+            (setq moe-theme-switcher--24h/sunrise 'midnight-sun
+                  moe-theme-switcher--24h/sunset 'midnight-sun))
         (progn                          ;Convert 12hr to 24hr
           (string-match "\\([0-9][0-9]?\\):\\([0-9][0-9]\\)\\([ap]m\\).+\\([0-9][0-9]?\\):\\([0-9][0-9]\\)\\([ap]m\\)" rise_set)
           (setq a (string-to-number (match-string 1 rise_set))
@@ -103,41 +110,41 @@ Take Keelung, Taiwan(25N,121E) for example, you can set like this:
                e (string-to-number (match-string 5 rise_set))
                f (match-string 6 rise_set))
          (if (equal c "pm")
-             (setq 24h/sunrise (list (+ 12 a) b))
-           (setq 24h/sunrise (list a b)))
+             (setq moe-theme-switcher--24h/sunrise (list (+ 12 a) b))
+           (setq moe-theme-switcher--24h/sunrise (list a b)))
          (if (equal f "pm")
-             (setq 24h/sunset (list (+ 12 d) e))
-           (setq 24h/sunset (list d e))))))))
+             (setq moe-theme-switcher--24h/sunset (list (+ 12 d) e))
+           (setq moe-theme-switcher--24h/sunset (list d e))))))))
 
 ;; Excute every minute.
-(defun switch-by-locale ()
-  (if (equal 24h/sunrise 'polar-night)  ;If polar-night...moe-dark!
-      (moe-load-theme 'dark)
-    (if (equal 24h/sunrise 'midnight-sun) ;If midnight-sun...moe-light!
-        (moe-load-theme 'light)
+(defun moe-theme-switcher--switch-by-locale ()
+  (if (equal moe-theme-switcher--24h/sunrise 'polar-night)  ;If polar-night...moe-dark!
+      (moe-theme-switcher--load-theme 'dark)
+    (if (equal moe-theme-switcher--24h/sunrise 'midnight-sun) ;If midnight-sun...moe-light!
+        (moe-theme-switcher--load-theme 'light)
       (progn
        (let ((now (list (string-to-number (format-time-string "%H"))
                         (string-to-number (format-time-string "%M")))))
          (if (and (or                        ;magic-logic [tm]
-                   (> (car now) (car 24h/sunrise))
+                   (> (car now) (car moe-theme-switcher--24h/sunrise))
                    (and
-                    (= (car now) (car 24h/sunrise))
-                    (>= (cadr now) (cadr 24h/sunrise))))
+                    (= (car now) (car moe-theme-switcher--24h/sunrise))
+                    (>= (cadr now) (cadr moe-theme-switcher--24h/sunrise))))
                   (or
-                   (< (car now) (car 24h/sunset))
+                   (< (car now) (car moe-theme-switcher--24h/sunset))
                    (and
-                    (= (car now) (car 24h/sunset))
-                    (< (cadr now) (cadr 24h/sunset)))))
-             (moe-load-theme 'light)
-           (moe-load-theme 'dark)
+                    (= (car now) (car moe-theme-switcher--24h/sunset))
+                    (< (cadr now) (cadr moe-theme-switcher--24h/sunset)))))
+             (moe-theme-switcher--load-theme 'light)
+           (moe-theme-switcher--load-theme 'dark)
            ))))))
 
-(defun moe-theme-auto-switch ()
+(defun moe-theme-switcher--auto-switch ()
   "Automatically switch between dark and light moe-theme."
   (interactive)
-  (if (boundp '24h/sunrise)
-      (switch-by-locale)
-    (switch-at-fixed-time))
+  (if (boundp 'moe-theme-switcher--24h/sunrise)
+      (moe-theme-switcher--switch-by-locale)
+    (moe-theme-switcher--switch-at-fixed-time))
   )
 
 (if (and
@@ -145,15 +152,15 @@ Take Keelung, Taiwan(25N,121E) for example, you can set like this:
      (boundp 'calendar-latitude)
      (eql moe-theme-switch-by-sunrise-and-sunset t))
     (progn
-      (run-with-timer 0 (* 60 60 24) 'convert-time-format-of-sunrise-and-sunset))
+      (run-with-timer 0 (* 60 60 24) 'moe-theme-switcher--compute-sunrise-sunset))
   ()
   )
 
-(setq moe-timer (run-with-timer 0 (* 1 60) 'moe-theme-auto-switch))
+(setq moe-theme-switcher--timer (run-with-timer 0 (* 1 60) 'moe-theme-switcher--auto-switch))
 
 ;; [FIXME] A minor-mode to enable/disable moe-theme-switcher
 (defun moe-theme-switcher-disable ()
   (interactive)
-  (cancel-timer moe-timer))
+  (cancel-timer moe-theme-switcher--timer))
 
 (provide 'moe-theme-switcher)

--- a/moe-theme-switcher.el
+++ b/moe-theme-switcher.el
@@ -38,8 +38,7 @@ local calendar.
 Take Keelung, Taiwan(25N,121E) for example, you can set like this:
 
 	(setq calendar-latitude +25)
-	(setq calendar-longitude +121)"
-)
+	(setq calendar-longitude +121)")
 
 (defvar moe-theme-switcher--which-enabled nil
   "Variable indicate which theme (moe-dark or light) is being used.")
@@ -139,16 +138,14 @@ Take Keelung, Taiwan(25N,121E) for example, you can set like this:
                     (= (car now) (car moe-theme-switcher--24h/sunset))
                     (< (cadr now) (cadr moe-theme-switcher--24h/sunset)))))
              (moe-theme-switcher--load-theme 'light)
-           (moe-theme-switcher--load-theme 'dark)
-           ))))))
+           (moe-theme-switcher--load-theme 'dark)))))))
 
 (defun moe-theme-switcher--auto-switch ()
   "Automatically switch between dark and light moe-theme."
   (interactive)
   (if (boundp 'moe-theme-switcher--24h/sunrise)
       (moe-theme-switcher--switch-by-locale)
-    (moe-theme-switcher--switch-at-fixed-time))
-  )
+    (moe-theme-switcher--switch-at-fixed-time)))
 
 (defun moe-theme-switcher-enable ()
   "Enable automatic switching between the `moe-light' and `moe-dark'

--- a/moe-theme.el
+++ b/moe-theme.el
@@ -9,7 +9,7 @@
 ;; Keywords: themes
 ;; X-URL: https://github.com/kuanyui/moe-theme.el
 ;; URL: https://github.com/kuanyui/moe-theme.el
-;; Version: 1.0.2
+;; Version: 1.1.0
 
 ;; This file is not part of GNU Emacs.
 ;;


### PR DESCRIPTION
This fixes a number of issues, most importantly the problem with the theme-switcher timer being forcibly enabled whenever the `moe-theme-switcher.el` file is loaded or its autoloads evaluated. This is an issue when using `package.el` or `use-package`, since these load all package files for the sake of bye-compilation. (`use-package` supports disabling this by adding the `:no-require` argument, but there is no way to prevent the behavior in `package.el`.)

The solution is to factor out all the top-level code to a function, which has to be explicitly run to enable it. We also take the opportunity to create a minor mode for convenience, which also gives us some added functionality like hooks.

Fixes #3
Fixes #31
Fixes #42
Fixes #68
Fixes #72