### PR TITLE
theme-switcher: Add autoload cookie

### DIFF
--- a/README.org
+++ b/README.org
@@ -172,7 +172,10 @@ between the =moe-light= and =moe-dark= themes automatically, to match
 the time of day. To enable it, you can use the following:
 
 #+BEGIN_SRC emacs-lisp
-  (require 'moe-theme-switcher)
+  ;; If moe-theme was installed manually as described above, uncomment
+  ;; the following:
+  ;; (require 'moe-theme-switcher)
+
   (setq calendar-latitude +25
         calendar-longitude +121
         moe-theme-switch-by-sunrise-and-sunset t)

--- a/moe-theme-switcher.el
+++ b/moe-theme-switcher.el
@@ -176,6 +176,7 @@ Otherwise, switch the the theme at fixed times (06:00 and 18:00)."
     (cancel-timer moe-theme-switcher--compute-sunrise-sunset-timer))
   (cancel-timer moe-theme-switcher--timer))
 
+;;;###autoload
 (define-minor-mode moe-theme-switcher-mode
   "Minor mode for enabling automatic switching between the
 `moe-light' and `moe-dark' themes accoring to the time of day.


### PR DESCRIPTION
Adds an autoload cookie to the new `moe-theme-switcher-mode` so that typical users can skip the call to `require`.

Thanks to Stefan Monnier for the feedback!